### PR TITLE
fix fetchWithBackoff fetch call syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,8 +425,6 @@
             for (let i = 0; i < retries; i++) {
                 try {
                     const response = await fetch(window.GEMINI_API_BASE, {
-{
-
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ prompt })


### PR DESCRIPTION
## Summary
- remove stray brace after fetch call in fetchWithBackoff
- ensure POST request uses proper headers and body

## Testing
- `node -c /tmp/fetch.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4daf064f88324adcc802020e63c3d